### PR TITLE
feat: Implement initial Notification module with Novu integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,104 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.notification</groupId>
+    <artifactId>notification-service</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.5</version> <!-- Or any recent stable version -->
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>11</java.version>
+        <!-- <novu.version>0.3.0</novu.version> --> <!-- Kept for history, but co.novu:novu-java:1.6.0 is used now -->
+        <spring-cloud-aws.version>2.4.4</spring-cloud-aws.version> <!-- Check for latest AWS SDK version -->
+        <lombok.version>1.18.24</lombok.version> <!-- Added lombok.version property -->
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- AWS SQS -->
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
+            <version>${spring-cloud-aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+            <version>1.12.333</version> <!-- Ensure this is compatible with spring-cloud-aws -->
+        </dependency>
+
+
+        <!-- Novu SDK -->
+        <dependency>
+            <groupId>co.novu</groupId> <!-- Corrected GroupId as per official docs -->
+            <artifactId>novu-java</artifactId> <!-- Corrected ArtifactId as per official docs -->
+            <version>1.6.0</version> <!-- Updated to latest version from official docs -->
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Spring Boot Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version> <!-- Or your current version -->
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version> <!-- Ensure you have a lombok.version property or use the direct version -->
+                        </path>
+                        <!-- Other annotation processors can be added here -->
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/notification/NotificationServiceApplication.java
+++ b/src/main/java/com/notification/NotificationServiceApplication.java
@@ -1,0 +1,12 @@
+package com.notification;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NotificationServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/notification/config/NovuConfig.java
+++ b/src/main/java/com/notification/config/NovuConfig.java
@@ -1,0 +1,45 @@
+package com.notification.config;
+
+import co.novu.sdk.Novu;
+import co.novu.sdk.NovuConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Configuration
+public class NovuConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(NovuConfig.class);
+
+    @Value("${novu.api.key}")
+    private String novuApiKey;
+
+    // Optional: Configure backend URL if needed, though SDK usually has a default
+    // @Value("${novu.backend.url:https://api.novu.co}")
+    // private String novuBackendUrl;
+
+    @Bean
+    public co.novu.sdk.NovuConfig novuSdkConfig() { // Renamed for clarity, returns the SDK's config object
+        if (novuApiKey == null || novuApiKey.isEmpty() || "YOUR_NOVU_API_KEY".equals(novuApiKey)) {
+            logger.warn("Novu API key is not configured or is using the default placeholder. Novu service might not be fully functional.");
+        }
+        // This bean provides the NovuConfig object, which can be injected elsewhere (like the service)
+        // if direct access to API key or other config details is needed from it.
+        return new co.novu.sdk.NovuConfig(novuApiKey);
+    }
+
+    @Bean
+    public Novu novu(co.novu.sdk.NovuConfig novuSdkConfig) { // Takes the NovuConfig bean as a parameter
+        // Configuration based on Novu SDK v1.6.0 (co.novu:novu-java)
+        // The Novu client is instantiated with a NovuConfig object.
+
+        // if (novuBackendUrl != null && !novuBackendUrl.isEmpty()) {
+        //    novuSdkConfig.setBackendUrl(novuBackendUrl); // Example if backend URL needs to be set
+        // }
+
+        logger.info("Configuring Novu client with SDK co.novu:novu-java.");
+        return new Novu(novuSdkConfig);
+    }
+}

--- a/src/main/java/com/notification/controller/NotificationController.java
+++ b/src/main/java/com/notification/controller/NotificationController.java
@@ -1,0 +1,68 @@
+package com.notification.controller;
+
+import com.notification.dto.EmailRequest;
+import com.notification.service.EmailSenderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * REST Controller for handling notification requests, such as sending emails.
+ */
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationController.class);
+
+    private final EmailSenderService emailSenderService;
+
+    /**
+     * Constructs a NotificationController with the necessary EmailSenderService.
+     *
+     * @param emailSenderService The service responsible for sending emails.
+     */
+    @Autowired
+    public NotificationController(EmailSenderService emailSenderService) {
+        this.emailSenderService = emailSenderService;
+    }
+
+    /**
+     * API endpoint to trigger sending an email.
+     * Accepts an {@link EmailRequest} and uses the {@link EmailSenderService} to dispatch the email.
+     *
+     * @param emailRequest The {@link EmailRequest} containing details for the email to be sent.
+     *                     The request body is validated based on annotations in {@link EmailRequest}.
+     * @return A {@link ResponseEntity} indicating the outcome of the operation.
+     *         Returns HTTP 202 (Accepted) if the email request is successfully processed for sending.
+     *         Returns HTTP 400 (Bad Request) if the input validation fails.
+     *         Returns HTTP 500 (Internal Server Error) if an unexpected error occurs during email processing.
+     */
+    @PostMapping("/email")
+    public ResponseEntity<String> sendEmail(@Valid @RequestBody EmailRequest emailRequest) {
+        logger.info("Received request to send email to: {}", emailRequest.getTo());
+        try {
+            emailSenderService.sendEmail(emailRequest);
+            logger.info("Email request for {} processed successfully.", emailRequest.getTo());
+            // Using 202 Accepted as email sending is often asynchronous.
+            // The request is accepted for processing, not necessarily sent and delivered instantly.
+            return ResponseEntity.status(HttpStatus.ACCEPTED).body("Email request accepted for processing.");
+        } catch (Exception e) {
+            // Specific exceptions like EmailSendingException or InvalidRequestException
+            // will be handled by the GlobalExceptionHandler.
+            // This catch block is for any other unexpected exceptions from the service layer,
+            // though ideally, services should wrap their exceptions.
+            logger.error("Error processing email request for {}: {}", emailRequest.getTo(), e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                 .body("An unexpected error occurred while processing the email request.");
+        }
+    }
+}

--- a/src/main/java/com/notification/dto/EmailRequest.java
+++ b/src/main/java/com/notification/dto/EmailRequest.java
@@ -1,0 +1,59 @@
+package com.notification.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the request payload for sending an email.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailRequest {
+
+    /**
+     * The primary recipient's email address. This field is mandatory.
+     */
+    @NotEmpty(message = "To email address cannot be empty.")
+    @Email(message = "Invalid 'to' email address format.")
+    private String to;
+
+    /**
+     * A list of CC recipients' email addresses. Optional.
+     */
+    private List<@Email(message = "Invalid 'cc' email address format.") String> cc;
+
+    /**
+     * A list of BCC recipients' email addresses. Optional.
+     */
+    private List<@Email(message = "Invalid 'bcc' email address format.") String> bcc;
+
+    /**
+     * The subject of the email. Optional.
+     */
+    private String subject;
+
+    /**
+     * The main content/body of the email. Optional.
+     */
+    private String body;
+
+    /**
+     * The signature to be appended to the email. Optional.
+     */
+    private String signature;
+
+    /**
+     * A map of variables that can be used for template substitution in the email body or subject. Optional.
+     * For example, {"userName": "John Doe", "orderNumber": "12345"}
+     */
+    private Map<String, Object> emailVariables;
+}

--- a/src/main/java/com/notification/exception/EmailSendingException.java
+++ b/src/main/java/com/notification/exception/EmailSendingException.java
@@ -1,0 +1,28 @@
+package com.notification.exception;
+
+/**
+ * Custom exception thrown when an error occurs while attempting to send an email.
+ * This could be due to issues with the email provider, invalid recipient addresses,
+ * or other related problems.
+ */
+public class EmailSendingException extends RuntimeException {
+
+    /**
+     * Constructs a new EmailSendingException with the specified detail message.
+     *
+     * @param message The detail message.
+     */
+    public EmailSendingException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new EmailSendingException with the specified detail message and cause.
+     *
+     * @param message The detail message.
+     * @param cause   The cause of the exception.
+     */
+    public EmailSendingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/notification/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/notification/exception/GlobalExceptionHandler.java
@@ -1,0 +1,127 @@
+package com.notification.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Global exception handler for the application.
+ * Catches defined custom exceptions and standard Spring exceptions to return appropriate HTTP responses.
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    /**
+     * Handles {@link InvalidRequestException}.
+     *
+     * @param ex      The exception.
+     * @param request The current web request.
+     * @return A {@link ResponseEntity} with HTTP 400 Bad Request status.
+     */
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<Object> handleInvalidRequestException(InvalidRequestException ex, WebRequest request) {
+        log.warn("Invalid request: {}", ex.getMessage());
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, ex.getMessage(), ex.getClass().getSimpleName());
+        return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
+    }
+
+    /**
+     * Handles {@link EmailSendingException}.
+     *
+     * @param ex      The exception.
+     * @param request The current web request.
+     * @return A {@link ResponseEntity} with HTTP 500 Internal Server Error status.
+     */
+    @ExceptionHandler(EmailSendingException.class)
+    public ResponseEntity<Object> handleEmailSendingException(EmailSendingException ex, WebRequest request) {
+        log.error("Email sending failed: {}", ex.getMessage(), ex);
+        ApiError apiError = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, "Error occurred while sending email.", ex.getClass().getSimpleName());
+        return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
+    }
+
+    /**
+     * Handles {@link MethodArgumentNotValidException}, which occurs when @Valid validation fails.
+     *
+     * @param ex      The exception.
+     * @param headers The headers.
+     * @param status  The HTTP status.
+     * @param request The current web request.
+     * @return A {@link ResponseEntity} with HTTP 400 Bad Request status and validation error details.
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.warn("Validation error: {}", ex.getMessage());
+        Map<String, String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, "Validation failed", errors);
+        return new ResponseEntity<>(apiError, headers, status);
+    }
+
+    /**
+     * Handles any other unhandled exceptions.
+     *
+     * @param ex      The exception.
+     * @param request The current web request.
+     * @return A {@link ResponseEntity} with HTTP 500 Internal Server Error status.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleAllOtherExceptions(Exception ex, WebRequest request) {
+        log.error("An unexpected error occurred: {}", ex.getMessage(), ex);
+        ApiError apiError = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred. Please try again later.", ex.getClass().getSimpleName());
+        return new ResponseEntity<>(apiError, new HttpHeaders(), apiError.getStatus());
+    }
+
+    /**
+     * Inner class to represent a structured API error response.
+     */
+    private static class ApiError {
+        private HttpStatus status;
+        private String message;
+        private String error;
+        private Map<String, String> fieldErrors;
+
+        public ApiError(HttpStatus status, String message, String error) {
+            this.status = status;
+            this.message = message;
+            this.error = error;
+        }
+
+        public ApiError(HttpStatus status, String message, Map<String, String> fieldErrors) {
+            this.status = status;
+            this.message = message;
+            this.fieldErrors = fieldErrors;
+        }
+
+        // Getters are needed for Jackson serialization
+        public HttpStatus getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public Map<String, String> getFieldErrors() {
+            return fieldErrors;
+        }
+    }
+}

--- a/src/main/java/com/notification/exception/InvalidRequestException.java
+++ b/src/main/java/com/notification/exception/InvalidRequestException.java
@@ -1,0 +1,32 @@
+package com.notification.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Custom exception for handling invalid client requests, typically due to validation errors
+ * or missing required parameters.
+ * Results in an HTTP 400 Bad Request response.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidRequestException extends RuntimeException {
+
+    /**
+     * Constructs a new InvalidRequestException with the specified detail message.
+     *
+     * @param message The detail message.
+     */
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new InvalidRequestException with the specified detail message and cause.
+     *
+     * @param message The detail message.
+     * @param cause   The cause of the exception.
+     */
+    public InvalidRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/notification/listener/SqsEmailListener.java
+++ b/src/main/java/com/notification/listener/SqsEmailListener.java
@@ -1,0 +1,95 @@
+package com.notification.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.dto.EmailRequest;
+import com.notification.service.EmailSenderService;
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+/**
+ * Listens to an AWS SQS queue for messages to trigger email sending.
+ */
+@Component
+public class SqsEmailListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(SqsEmailListener.class);
+
+    private final EmailSenderService emailSenderService;
+    private final ObjectMapper objectMapper;
+    private final Validator validator;
+
+    /**
+     * Constructs an SqsEmailListener.
+     *
+     * @param emailSenderService Service to send emails.
+     * @param objectMapper     For deserializing JSON messages from SQS.
+     * @param validator        For validating the deserialized {@link EmailRequest}.
+     */
+    @Autowired
+    public SqsEmailListener(EmailSenderService emailSenderService, ObjectMapper objectMapper, Validator validator) {
+        this.emailSenderService = emailSenderService;
+        this.objectMapper = objectMapper;
+        this.validator = validator;
+    }
+
+    /**
+     * Listens to the configured SQS queue for incoming messages.
+     * Messages are expected to be JSON strings that can be deserialized into {@link EmailRequest}.
+     *
+     * @param message        The raw message content (JSON string) from SQS.
+     * @param messageId      The SQS message ID, injected from the message headers.
+     * @param approximateFirstReceiveTimestamp The approximate time the message was first received, for logging.
+     */
+    @SqsListener(value = "${cloud.aws.sqs.queue.name}", deletionPolicy = io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS)
+    public void receiveEmailRequest(String message,
+                                    @Header("MessageId") String messageId, // Standard SQS message attribute
+                                    @Header(name = "ApproximateFirstReceiveTimestamp", required = false) String approximateFirstReceiveTimestamp) { // SQS attribute
+        logger.info("Received SQS message ID: {}. ApproxFirstReceiveTimestamp: {}. Payload: {}", messageId, approximateFirstReceiveTimestamp, message);
+
+        try {
+            EmailRequest emailRequest = objectMapper.readValue(message, EmailRequest.class);
+            logger.info("Deserialized SQS message to EmailRequest for recipient: {}", emailRequest.getTo());
+
+            Set<ConstraintViolation<EmailRequest>> violations = validator.validate(emailRequest);
+            if (!violations.isEmpty()) {
+                String errorMessages = violations.stream()
+                                                 .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                                                 .collect(Collectors.joining(", "));
+                logger.error("Validation failed for EmailRequest from SQS message ID {}: {}. Dropping message.", messageId, errorMessages);
+                // Message will not be deleted due to SqsListener. оригиналаSqsMessageDeletionPolicy.ON_SUCCESS
+                // if an exception is thrown. If we want to discard it, we should not throw.
+                // Consider moving to DLQ if validation fails permanently. For now, log and it won't be retried by this listener instance after exception.
+                // To ensure it's not reprocessed and potentially stuck, either ensure a DLQ is configured on SQS,
+                // or catch this and don't rethrow if the message is truly unprocessable.
+                // For now, we'll let it throw, assuming DLQ handles persistent bad messages.
+                throw new IllegalArgumentException("Invalid EmailRequest from SQS: " + errorMessages);
+            }
+
+            emailSenderService.sendEmail(emailRequest);
+            logger.info("Successfully processed SQS message ID {} and triggered email for: {}", messageId, emailRequest.getTo());
+        } catch (JsonProcessingException e) {
+            logger.error("Failed to deserialize SQS message ID {} into EmailRequest. Message content: {}. Error: {}", messageId, message, e.getMessage(), e);
+            // This is likely a malformed message. It might need to go to a DLQ.
+            // Throwing an exception will make SQS redeliver it until maxReceiveCount, then DLQ (if configured).
+            throw new RuntimeException("SQS message deserialization error for messageId " + messageId, e);
+        } catch (IllegalArgumentException e) {
+            // Validation error already logged. Rethrow to ensure SQS handles it (e.g., DLQ).
+            throw e;
+        } catch (Exception e) {
+            logger.error("Error processing SQS message ID {} for email request. Error: {}", messageId, e.getMessage(), e);
+            // For other errors (e.g., EmailSendingException), rethrow so SQS can retry or DLQ.
+            throw new RuntimeException("Generic error processing SQS messageId " + messageId, e);
+        }
+    }
+}

--- a/src/main/java/com/notification/service/EmailSenderService.java
+++ b/src/main/java/com/notification/service/EmailSenderService.java
@@ -1,0 +1,18 @@
+package com.notification.service;
+
+import com.notification.dto.EmailRequest;
+
+/**
+ * Interface for services that send emails.
+ * This abstraction allows for different implementations of email sending logic.
+ */
+public interface EmailSenderService {
+
+    /**
+     * Sends an email based on the provided request details.
+     *
+     * @param request The {@link EmailRequest} containing all necessary information for sending the email.
+     * @throws com.notification.exception.EmailSendingException if an error occurs during email dispatch.
+     */
+    void sendEmail(EmailRequest request);
+}

--- a/src/main/java/com/notification/service/impl/NovuEmailSenderServiceImpl.java
+++ b/src/main/java/com/notification/service/impl/NovuEmailSenderServiceImpl.java
@@ -1,0 +1,125 @@
+package com.notification.service.impl;
+
+import co.novu.api.events.requests.TriggerEventRequest;
+import co.novu.api.events.responses.EventResponse; // Corrected import
+import co.novu.api.events.pojos.Subscriber; // Corrected import
+import co.novu.sdk.Novu; // Corrected import
+import co.novu.sdk.NovuConfig; // Corrected import
+import com.notification.dto.EmailRequest;
+import com.notification.exception.EmailSendingException;
+import com.notification.service.EmailSenderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of {@link EmailSenderService} that uses Novu to send emails.
+ * This version is updated for Novu SDK `co.novu:novu-java:1.6.0`.
+ */
+@Service
+public class NovuEmailSenderServiceImpl implements EmailSenderService {
+
+    private static final Logger logger = LoggerFactory.getLogger(NovuEmailSenderServiceImpl.class);
+
+    private final Novu novu; // Correct SDK class
+    private final NovuConfig novuConfig; // Correct SDK class, used for API key check
+
+    @Value("${novu.workflow.trigger.id:default-email-workflow}")
+    private String novuWorkflowTriggerId;
+
+    public NovuEmailSenderServiceImpl(Novu novu, NovuConfig novuConfig) { // Correct constructor params
+        this.novu = novu;
+        this.novuConfig = novuConfig;
+    }
+
+    /**
+     * Sends an email using the Novu service.
+     *
+     * @param request The {@link EmailRequest} containing email details.
+     * @throws EmailSendingException if Novu fails to trigger the event or if the API key is not set.
+     */
+    @Override
+    public void sendEmail(EmailRequest request) {
+        if (novu == null || novuConfig == null || novuConfig.getApiKey() == null || novuConfig.getApiKey().isEmpty() || "YOUR_NOVU_API_KEY".equals(novuConfig.getApiKey())) {
+            logger.error("Novu API key is not configured. Cannot send email.");
+            throw new EmailSendingException("Novu service is not configured. API key missing.");
+        }
+
+        Map<String, Object> payload = new HashMap<>();
+        if (request.getEmailVariables() != null) {
+            payload.putAll(request.getEmailVariables());
+        }
+        payload.put("emailSubject", request.getSubject());
+        payload.put("emailBody", request.getBody());
+        payload.put("emailSignature", request.getSignature());
+
+        List<Subscriber> toSubscribers = new ArrayList<>();
+        Subscriber mainRecipient = new Subscriber();
+        mainRecipient.setSubscriberId(request.getTo());
+        mainRecipient.setEmail(request.getTo());
+        toSubscribers.add(mainRecipient);
+
+        TriggerEventRequest triggerEventRequest = new TriggerEventRequest();
+        triggerEventRequest.setName(novuWorkflowTriggerId);
+        triggerEventRequest.setPayload(payload);
+        triggerEventRequest.setTo(toSubscribers);
+
+        try {
+            logger.info("Triggering Novu event '{}' for recipient: {}", novuWorkflowTriggerId, request.getTo());
+            EventResponse response = novu.triggerEvent(triggerEventRequest); // Correct response type
+
+            // Check response data carefully as per co.novu.api.events.responses.EventResponseData
+            if (response == null || response.getData() == null || !Boolean.TRUE.equals(response.getData().getAcknowledged()) || !"triggered".equalsIgnoreCase(response.getData().getStatus())) {
+                logger.error("Novu event trigger failed or was not acknowledged for {}. Response: {}", request.getTo(), response);
+                throw new EmailSendingException("Failed to trigger Novu event for email to " + request.getTo() + ". Status: " + (response != null && response.getData() != null ? response.getData().getStatus() : "N/A"));
+            }
+
+            logger.info("Novu event triggered successfully for {}. TransactionId: {}", request.getTo(), response.getData().getTransactionId());
+
+            if (request.getCc() != null && !request.getCc().isEmpty()) {
+                triggerForAdditionalRecipients(request.getCc(), payload, "CC");
+            }
+            if (request.getBcc() != null && !request.getBcc().isEmpty()) {
+                triggerForAdditionalRecipients(request.getBcc(), payload, "BCC");
+            }
+
+        } catch (Exception e) {
+            logger.error("Error sending email via Novu to {}: {}", request.getTo(), e.getMessage(), e);
+            throw new EmailSendingException("Error sending email via Novu to " + request.getTo() + ": " + e.getMessage(), e);
+        }
+    }
+
+    private void triggerForAdditionalRecipients(List<String> recipientEmails, Map<String, Object> basePayload, String type) {
+        for (String email : recipientEmails) {
+            List<Subscriber> toSubscribers = new ArrayList<>();
+            Subscriber recipient = new Subscriber(); // Correct Subscriber class
+            recipient.setSubscriberId(email);
+            recipient.setEmail(email);
+            toSubscribers.add(recipient);
+
+            TriggerEventRequest additionalTrigger = new TriggerEventRequest();
+            additionalTrigger.setName(novuWorkflowTriggerId);
+            additionalTrigger.setPayload(new HashMap<>(basePayload));
+            additionalTrigger.setTo(toSubscribers);
+
+            try {
+                logger.info("Triggering Novu event '{}' for {} recipient: {}", novuWorkflowTriggerId, type, email);
+                EventResponse response = novu.triggerEvent(additionalTrigger); // Correct response type
+
+                if (response == null || response.getData() == null || !Boolean.TRUE.equals(response.getData().getAcknowledged()) || !"triggered".equalsIgnoreCase(response.getData().getStatus())) {
+                    logger.error("Novu event trigger failed or was not acknowledged for {} recipient {}. Response: {}", type, email, response);
+                } else {
+                    logger.info("Novu event triggered successfully for {} recipient {}. TransactionId: {}", type, email, response.getData().getTransactionId());
+                }
+            } catch (Exception e) {
+                logger.error("Error sending {} email via Novu to {}: {}", type, email, e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,43 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: notification-service
+
+# AWS Configuration
+cloud:
+  aws:
+    region:
+      static: YOUR_AWS_REGION # e.g., us-east-1
+    credentials:
+      access-key: YOUR_AWS_ACCESS_KEY
+      secret-key: YOUR_AWS_SECRET_KEY
+    sqs:
+      queue:
+        name: YOUR_SQS_QUEUE_NAME
+        url: YOUR_SQS_QUEUE_URL # Optional if name is provided and region is configured
+
+# Novu Configuration
+novu:
+  api:
+    key: YOUR_NOVU_API_KEY
+  # Add any other Novu specific configurations if needed
+  # e.g. Novu endpoint if it's not the default one used by the SDK
+
+logging:
+  level:
+    com.notification: INFO
+    org.springframework.web: INFO
+    io.novu: INFO
+    com.amazonaws: WARN
+
+# Management endpoints (optional, but good for health checks)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always

--- a/src/test/java/com/notification/NotificationServiceApplicationTests.java
+++ b/src/test/java/com/notification/NotificationServiceApplicationTests.java
@@ -1,0 +1,17 @@
+package com.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test") // Example: use an application-test.yml if needed
+class NotificationServiceApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // Verifies that the Spring application context can start successfully.
+        // If this test passes, it means all Spring configurations are correctly set up,
+        // beans can be instantiated and injected, etc.
+    }
+}

--- a/src/test/java/com/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,142 @@
+package com.notification.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.dto.EmailRequest;
+import com.notification.exception.EmailSendingException;
+import com.notification.service.EmailSenderService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EmailSenderService emailSenderService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void sendEmail_success() throws Exception {
+        EmailRequest emailRequest = EmailRequest.builder()
+                .to("test@example.com")
+                .subject("Test Subject")
+                .body("Hello World")
+                .cc(Collections.singletonList("cc@example.com"))
+                .emailVariables(Map.of("user", "John"))
+                .build();
+
+        doNothing().when(emailSenderService).sendEmail(any(EmailRequest.class));
+
+        mockMvc.perform(post("/api/v1/notifications/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emailRequest)))
+                .andExpect(status().isAccepted())
+                .andExpect(content().string("Email request accepted for processing."));
+
+        verify(emailSenderService).sendEmail(any(EmailRequest.class));
+    }
+
+    @Test
+    void sendEmail_validationError_missingTo() throws Exception {
+        EmailRequest emailRequest = EmailRequest.builder()
+                // .to("test@example.com") // 'to' is missing
+                .subject("Test Subject")
+                .build();
+
+        mockMvc.perform(post("/api/v1/notifications/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emailRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.fieldErrors.to").value("To email address cannot be empty."));
+    }
+
+    @Test
+    void sendEmail_validationError_invalidEmailFormat() throws Exception {
+        EmailRequest emailRequest = EmailRequest.builder()
+                .to("invalid-email")
+                .subject("Test Subject")
+                .build();
+
+        mockMvc.perform(post("/api/v1/notifications/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emailRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.fieldErrors.to").value("Invalid 'to' email address format."));
+    }
+
+    @Test
+    void sendEmail_validationError_invalidCcEmailFormat() throws Exception {
+        EmailRequest emailRequest = EmailRequest.builder()
+                .to("valid@example.com")
+                .cc(Collections.singletonList("invalid-cc-email"))
+                .subject("Test Subject")
+                .build();
+
+        mockMvc.perform(post("/api/v1/notifications/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emailRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.fieldErrors['cc[0]']").value("Invalid 'cc' email address format."));
+    }
+
+
+    @Test
+    void sendEmail_serviceThrowsEmailSendingException() throws Exception {
+        EmailRequest emailRequest = EmailRequest.builder()
+                .to("test@example.com")
+                .subject("Failure Test")
+                .build();
+
+        doThrow(new EmailSendingException("Novu unavailable")).when(emailSenderService).sendEmail(any(EmailRequest.class));
+
+        mockMvc.perform(post("/api/v1/notifications/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emailRequest)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("Error occurred while sending email."))
+                .andExpect(jsonPath("$.error").value("EmailSendingException"));
+    }
+
+    @Test
+    void sendEmail_serviceThrowsUnexpectedException() throws Exception {
+        EmailRequest emailRequest = EmailRequest.builder()
+                .to("test@example.com")
+                .subject("Failure Test")
+                .build();
+
+        // Simulate a generic runtime exception from the service layer
+        doThrow(new RuntimeException("Unexpected database error")).when(emailSenderService).sendEmail(any(EmailRequest.class));
+
+        mockMvc.perform(post("/api/v1/notifications/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(emailRequest)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("An unexpected error occurred while processing the email request."));
+                // The GlobalExceptionHandler's generic handler for Exception.class will be invoked by Spring,
+                // but the controller's own try-catch block for Exception might catch it first if the service call is direct.
+                // Let's adjust the expectation based on the controller's direct catch block.
+    }
+}

--- a/src/test/java/com/notification/listener/SqsEmailListenerTest.java
+++ b/src/test/java/com/notification/listener/SqsEmailListenerTest.java
@@ -1,0 +1,121 @@
+package com.notification.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notification.dto.EmailRequest;
+import com.notification.service.EmailSenderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Path;
+import javax.validation.Validator;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SqsEmailListenerTest {
+
+    @Mock
+    private EmailSenderService emailSenderService;
+
+    @Spy // Using a real ObjectMapper instance
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Validator validator;
+
+    @InjectMocks
+    private SqsEmailListener sqsEmailListener;
+
+    private EmailRequest validEmailRequest;
+    private String validEmailRequestJson;
+
+    @BeforeEach
+    void setUp() throws JsonProcessingException {
+        validEmailRequest = EmailRequest.builder()
+                .to("test@example.com")
+                .subject("SQS Test")
+                .body("Message from SQS")
+                .build();
+        validEmailRequestJson = objectMapper.writeValueAsString(validEmailRequest);
+
+        // Default behavior for validator: no violations
+        when(validator.validate(any(EmailRequest.class))).thenReturn(Collections.emptySet());
+    }
+
+    @Test
+    void receiveEmailRequest_success() {
+        doNothing().when(emailSenderService).sendEmail(any(EmailRequest.class));
+
+        assertDoesNotThrow(() -> sqsEmailListener.receiveEmailRequest(validEmailRequestJson, "msg-id-123", "timestamp"));
+
+        verify(objectMapper).readValue(eq(validEmailRequestJson), eq(EmailRequest.class));
+        verify(validator).validate(any(EmailRequest.class));
+        verify(emailSenderService).sendEmail(any(EmailRequest.class));
+    }
+
+    @Test
+    void receiveEmailRequest_jsonProcessingException() throws JsonProcessingException {
+        String malformedJson = "{\"to\":\"test@example.com\", subject"; // Malformed
+
+        // Mock objectMapper to throw JsonProcessingException for this specific malformed JSON.
+        // Since objectMapper is a spy, we can mock specific methods.
+        // However, it's easier to just pass malformed JSON and let the real method throw.
+        // Forcing specific exception type from a mocked readValue:
+        // when(objectMapper.readValue(eq(malformedJson), eq(EmailRequest.class))).thenThrow(JsonProcessingException.class);
+
+        assertThrows(RuntimeException.class, () -> {
+            sqsEmailListener.receiveEmailRequest(malformedJson, "msg-id-error", "timestamp");
+        }, "SQS message deserialization error for messageId msg-id-error");
+
+        verify(emailSenderService, never()).sendEmail(any());
+    }
+
+    @Test
+    void receiveEmailRequest_validationFailed() {
+        // Simulate validation failure
+        Set<ConstraintViolation<EmailRequest>> violations = new HashSet<>();
+        ConstraintViolation<EmailRequest> violation = mock(ConstraintViolation.class);
+        Path propertyPath = mock(Path.class);
+        when(propertyPath.toString()).thenReturn("to");
+        when(violation.getPropertyPath()).thenReturn(propertyPath);
+        when(violation.getMessage()).thenReturn("must not be blank");
+        violations.add(violation);
+
+        when(validator.validate(any(EmailRequest.class))).thenReturn(violations);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            sqsEmailListener.receiveEmailRequest(validEmailRequestJson, "msg-id-validation-fail", "timestamp");
+        });
+
+        assertTrue(exception.getMessage().contains("Invalid EmailRequest from SQS: to: must not be blank"));
+        verify(emailSenderService, never()).sendEmail(any());
+    }
+
+    @Test
+    void receiveEmailRequest_emailServiceThrowsException() {
+        doThrow(new RuntimeException("Email service failure")).when(emailSenderService).sendEmail(any(EmailRequest.class));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            sqsEmailListener.receiveEmailRequest(validEmailRequestJson, "msg-id-service-fail", "timestamp");
+        });
+
+        assertTrue(exception.getMessage().contains("Generic error processing SQS messageId msg-id-service-fail"));
+        assertEquals("Email service failure", exception.getCause().getMessage());
+
+        verify(emailSenderService).sendEmail(any(EmailRequest.class));
+    }
+}

--- a/src/test/java/com/notification/service/impl/NovuEmailSenderServiceImplTest.java
+++ b/src/test/java/com/notification/service/impl/NovuEmailSenderServiceImplTest.java
@@ -1,0 +1,243 @@
+package com.notification.service.impl;
+
+// Updated imports for co.novu SDK
+import co.novu.api.events.pojos.Subscriber;
+import co.novu.api.events.requests.TriggerEventRequest;
+import co.novu.api.events.responses.EventResponse;
+import co.novu.api.events.responses.EventResponseData;
+import co.novu.sdk.Novu;
+import co.novu.sdk.NovuConfig;
+
+import com.notification.dto.EmailRequest;
+import com.notification.exception.EmailSendingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class NovuEmailSenderServiceImplTest {
+
+    @Mock
+    private Novu novuMock;
+
+    @Mock
+    private NovuConfig novuSdkConfigMock; // This is co.novu.sdk.NovuConfig
+
+    private NovuEmailSenderServiceImpl novuEmailSenderService;
+
+    private final String testWorkflowTriggerId = "test-workflow";
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        // Manually instantiate the service with mocked dependencies
+        novuEmailSenderService = new NovuEmailSenderServiceImpl(novuMock, novuSdkConfigMock);
+
+        when(novuSdkConfigMock.getApiKey()).thenReturn("test-api-key");
+        ReflectionTestUtils.setField(novuEmailSenderService, "novuWorkflowTriggerId", testWorkflowTriggerId);
+    }
+
+    @Test
+    void sendEmail_success_mainRecipientOnly() {
+        EmailRequest request = EmailRequest.builder()
+                .to("test@example.com")
+                .subject("Test Subject")
+                .body("Test Body")
+                .emailVariables(Map.of("name", "Tester"))
+                .build();
+
+        EventResponse mockResponse = new EventResponse();
+        EventResponseData responseData = new EventResponseData();
+        responseData.setStatus("triggered");
+        responseData.setTransactionId("tx_123");
+        responseData.setAcknowledged(true); // Correct place for acknowledged
+        mockResponse.setData(responseData);
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenReturn(mockResponse);
+
+        novuEmailSenderService.sendEmail(request);
+
+        ArgumentCaptor<TriggerEventRequest> captor = ArgumentCaptor.forClass(TriggerEventRequest.class);
+        verify(novuMock, times(1)).triggerEvent(captor.capture());
+
+        TriggerEventRequest triggeredRequest = captor.getValue();
+        assertEquals(testWorkflowTriggerId, triggeredRequest.getName());
+        assertNotNull(triggeredRequest.getTo());
+        assertEquals(1, triggeredRequest.getTo().size());
+        assertEquals("test@example.com", triggeredRequest.getTo().get(0).getEmail());
+        assertEquals("test@example.com", triggeredRequest.getTo().get(0).getSubscriberId()); // Assuming email is subscriberId
+        assertEquals("Tester", triggeredRequest.getPayload().get("name"));
+        assertEquals("Test Subject", triggeredRequest.getPayload().get("emailSubject"));
+    }
+
+    @Test
+    void sendEmail_success_withCcAndBcc() {
+        EmailRequest request = EmailRequest.builder()
+                .to("to@example.com")
+                .cc(Arrays.asList("cc1@example.com", "cc2@example.com"))
+                .bcc(Collections.singletonList("bcc@example.com"))
+                .subject("Test Subject CC BCC")
+                .body("Test Body")
+                .build();
+
+        EventResponse mockResponse = new EventResponse();
+        EventResponseData responseData = new EventResponseData();
+        responseData.setStatus("triggered");
+        responseData.setTransactionId("tx_123_variant"); // Ensure unique transaction IDs if necessary for distinction
+        responseData.setAcknowledged(true);
+        mockResponse.setData(responseData);
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenReturn(mockResponse);
+
+        novuEmailSenderService.sendEmail(request);
+
+        ArgumentCaptor<TriggerEventRequest> captor = ArgumentCaptor.forClass(TriggerEventRequest.class);
+        verify(novuMock, times(4)).triggerEvent(captor.capture());
+
+        List<TriggerEventRequest> allRequests = captor.getAllValues();
+
+        assertTrue(allRequests.stream().anyMatch(r -> "to@example.com".equals(r.getTo().get(0).getEmail())));
+        assertTrue(allRequests.stream().anyMatch(r -> "cc1@example.com".equals(r.getTo().get(0).getEmail())));
+        assertTrue(allRequests.stream().anyMatch(r -> "cc2@example.com".equals(r.getTo().get(0).getEmail())));
+        assertTrue(allRequests.stream().anyMatch(r -> "bcc@example.com".equals(r.getTo().get(0).getEmail())));
+
+        allRequests.forEach(r -> {
+            assertEquals(testWorkflowTriggerId, r.getName());
+            assertEquals("Test Subject CC BCC", r.getPayload().get("emailSubject"));
+            assertEquals(1, r.getTo().size());
+        });
+    }
+
+    @Test
+    void sendEmail_novuApiKeyNotConfigured_throwsEmailSendingException() {
+        when(novuSdkConfigMock.getApiKey()).thenReturn(null);
+
+        EmailRequest request = EmailRequest.builder().to("test@example.com").build();
+
+        EmailSendingException exception = assertThrows(EmailSendingException.class, () -> {
+            novuEmailSenderService.sendEmail(request);
+        });
+        assertEquals("Novu service is not configured. API key missing.", exception.getMessage());
+        verify(novuMock, never()).triggerEvent(any());
+    }
+
+    @Test
+    void sendEmail_novuReturnsFailure_notAcknowledged_throwsEmailSendingException() {
+        EmailRequest request = EmailRequest.builder().to("test@example.com").subject("Test").build();
+
+        EventResponse mockResponse = new EventResponse();
+        EventResponseData responseData = new EventResponseData();
+        responseData.setAcknowledged(false);
+        responseData.setStatus("error"); // Or some other non-triggered status
+        mockResponse.setData(responseData);
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenReturn(mockResponse);
+
+        EmailSendingException exception = assertThrows(EmailSendingException.class, () -> {
+            novuEmailSenderService.sendEmail(request);
+        });
+        assertTrue(exception.getMessage().contains("Failed to trigger Novu event for email to test@example.com"));
+    }
+     @Test
+    void sendEmail_novuReturnsNullResponse_throwsEmailSendingException() {
+        EmailRequest request = EmailRequest.builder().to("test@example.com").subject("Test").build();
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenReturn(null);
+
+        EmailSendingException exception = assertThrows(EmailSendingException.class, () -> {
+            novuEmailSenderService.sendEmail(request);
+        });
+        assertTrue(exception.getMessage().contains("Failed to trigger Novu event for email to test@example.com"));
+    }
+
+    @Test
+    void sendEmail_novuReturnsNullResponseData_throwsEmailSendingException() {
+        EmailRequest request = EmailRequest.builder().to("test@example.com").subject("Test").build();
+        EventResponse mockResponse = new EventResponse();
+        mockResponse.setData(null); // Explicitly set data to null
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenReturn(mockResponse);
+
+        EmailSendingException exception = assertThrows(EmailSendingException.class, () -> {
+            novuEmailSenderService.sendEmail(request);
+        });
+        assertTrue(exception.getMessage().contains("Failed to trigger Novu event for email to test@example.com"));
+    }
+
+
+    @Test
+    void sendEmail_novuReturnsFailure_statusNotTriggered_throwsEmailSendingException() {
+        EmailRequest request = EmailRequest.builder().to("test@example.com").subject("Test").build();
+
+        EventResponse mockResponse = new EventResponse();
+        EventResponseData responseData = new EventResponseData();
+        responseData.setAcknowledged(true);
+        responseData.setStatus("processed");
+        mockResponse.setData(responseData);
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenReturn(mockResponse);
+
+        EmailSendingException exception = assertThrows(EmailSendingException.class, () -> {
+            novuEmailSenderService.sendEmail(request);
+        });
+        assertTrue(exception.getMessage().contains("Failed to trigger Novu event for email to test@example.com"));
+    }
+
+    @Test
+    void sendEmail_novuThrowsException_throwsEmailSendingException() {
+        EmailRequest request = EmailRequest.builder().to("test@example.com").subject("Test").build();
+
+        when(novuMock.triggerEvent(any(TriggerEventRequest.class))).thenThrow(new RuntimeException("Novu internal error"));
+
+        EmailSendingException exception = assertThrows(EmailSendingException.class, () -> {
+            novuEmailSenderService.sendEmail(request);
+        });
+        assertTrue(exception.getMessage().contains("Error sending email via Novu to test@example.com"));
+        assertTrue(exception.getCause() instanceof RuntimeException);
+        assertEquals("Novu internal error", exception.getCause().getMessage());
+    }
+
+    @Test
+    void sendEmail_partialFailure_forCcRecipient_doesNotStopProcessing() {
+        EmailRequest request = EmailRequest.builder()
+                .to("to@example.com")
+                .cc(Arrays.asList("cc.success@example.com", "cc.fail@example.com"))
+                .subject("Test Partial Failure")
+                .build();
+
+        EventResponse successResponse = new EventResponse();
+        EventResponseData successData = new EventResponseData();
+        successData.setStatus("triggered");
+        successData.setTransactionId("tx_success");
+        successData.setAcknowledged(true);
+        successResponse.setData(successData);
+
+        EventResponse failureResponse = new EventResponse();
+        EventResponseData failureData = new EventResponseData();
+        failureData.setAcknowledged(false);
+        failureData.setStatus("error");
+        failureResponse.setData(failureData);
+
+        when(novuMock.triggerEvent(argThat(argument -> "to@example.com".equals(argument.getTo().get(0).getEmail()))))
+                .thenReturn(successResponse);
+        when(novuMock.triggerEvent(argThat(argument -> "cc.success@example.com".equals(argument.getTo().get(0).getEmail()))))
+                .thenReturn(successResponse);
+        when(novuMock.triggerEvent(argThat(argument -> "cc.fail@example.com".equals(argument.getTo().get(0).getEmail()))))
+                .thenReturn(failureResponse);
+
+        assertDoesNotThrow(() -> novuEmailSenderService.sendEmail(request));
+
+        verify(novuMock, times(3)).triggerEvent(any(TriggerEventRequest.class));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,53 @@
+# Test specific properties can go here.
+# For example, if you want to use an embedded database or different AWS/Novu keys for tests.
+
+server:
+  port: 0 # Use a random available port for tests to avoid conflicts
+
+spring:
+  application:
+    name: notification-service-test
+
+# Disable AWS SQS listeners during most tests unless specifically testing them
+# to avoid trying to connect to a real SQS queue.
+# For @SpringBootTest that needs SQS, this can be overridden via @TestPropertySource
+# or by not using this profile for those specific tests.
+cloud:
+  aws:
+    sqs:
+      enabled: false # Disable SQS listener auto-configuration for tests
+    region:
+      static: us-east-1 # Dummy region for tests
+    credentials:
+      access-key: testAccessKey
+      secret-key: testSecretKey
+
+novu:
+  api:
+    key: TEST_NOVU_API_KEY_FOR_UNIT_TESTS
+  workflow:
+    trigger:
+      id: test-email-workflow # Consistent trigger ID for tests
+
+logging:
+  level:
+    com.notification: DEBUG
+    org.springframework.web: INFO
+    io.novu: INFO # Novu SDK logging can be noisy, adjust as needed
+    com.amazonaws: WARN
+
+# Ensure SQS listener doesn't try to start for most tests
+# This is an alternative way to disable listeners if `cloud.aws.sqs.enabled=false` isn't sufficient
+# or if you use a different SQS library.
+# For `io.awspring.cloud:spring-cloud-starter-aws-messaging`:
+# The `cloud.aws.sqs.enabled` should work.
+# Another approach is to mock the SqsListener bean itself in test configurations.
+# Or, ensure the queue name property is not set or points to a dummy value that won't be listened to.
+# Example: cloud.aws.sqs.queue.name: "do-not-listen-test-queue"
+
+# If using @SqsListener, it will try to create a client.
+# Ensure the AWS SDK client beans are either mocked or configured for local testing (e.g. LocalStack)
+# if you run integration tests that involve SQS.
+# For component tests that don't need real AWS interaction, mocking SqsClient is a good idea.
+# The `spring-cloud-aws-autoconfigure` will try to create default SQS client.
+# Setting dummy credentials and region helps avoid errors if it does try.

--- a/target/classes/application.yml
+++ b/target/classes/application.yml
@@ -1,0 +1,43 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: notification-service
+
+# AWS Configuration
+cloud:
+  aws:
+    region:
+      static: YOUR_AWS_REGION # e.g., us-east-1
+    credentials:
+      access-key: YOUR_AWS_ACCESS_KEY
+      secret-key: YOUR_AWS_SECRET_KEY
+    sqs:
+      queue:
+        name: YOUR_SQS_QUEUE_NAME
+        url: YOUR_SQS_QUEUE_URL # Optional if name is provided and region is configured
+
+# Novu Configuration
+novu:
+  api:
+    key: YOUR_NOVU_API_KEY
+  # Add any other Novu specific configurations if needed
+  # e.g. Novu endpoint if it's not the default one used by the SDK
+
+logging:
+  level:
+    com.notification: INFO
+    org.springframework.web: INFO
+    io.novu: INFO
+    com.amazonaws: WARN
+
+# Management endpoints (optional, but good for health checks)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
Summary of changes:

Project Setup & Core Logic:
- Initialized Spring Boot project with Maven (Web, Validation, AWS SQS, Novu, Lombok, Test).
- Created application.yml for configurations.
- Implemented EmailRequest DTO with validation.
- Defined EmailSenderService interface and NovuEmailSenderServiceImpl using Novu SDK co.novu:novu-java:1.6.0.
- Configured Novu client in NovuConfig.java.
- Created NotificationController with a POST endpoint for email triggering.
- Implemented SqsEmailListener for asynchronous email triggering.
- Added custom exceptions (EmailSendingException, InvalidRequestException) and a GlobalExceptionHandler.
- Integrated SLF4J logging.

Dependency Resolution & Build Issues:
- Resolved Novu SDK dependency issues by finding correct coordinates (co.novu:novu-java:1.6.0) after multiple attempts with incorrect ones.
- Updated Novu integration code to match the correct SDK version.
- Addressed a java.lang.NoSuchFieldError during compilation by explicitly configuring Lombok annotationProcessorPaths in pom.xml and defining lombok.version.

Testing:
- Added unit tests for NovuEmailSenderServiceImpl, NotificationController, and SqsEmailListener.
- Included Spring context loading test and test-specific application.yml.

Current Status:
The latest change was to address a `java.lang.NoSuchFieldError` by configuring Lombok explicitly. I haven't run the build after this specific change. Further testing is required to confirm the resolution of this build error and the overall functionality.